### PR TITLE
Develop: Add Analysis Screen

### DIFF
--- a/Plutus.xcodeproj/project.pbxproj
+++ b/Plutus.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		B875497125B3D01500D646F2 /* TickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B875497025B3D01500D646F2 /* TickerView.swift */; };
 		B8F7827025B394210015B8DF /* DateRangePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F7826F25B394200015B8DF /* DateRangePickerView.swift */; };
 		B8F7827825B3942F0015B8DF /* ComparsionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F7827725B3942F0015B8DF /* ComparsionCardView.swift */; };
-		B8F7828D25B39C0D0015B8DF /* SFSafeSymbols in Frameworks */ = {isa = PBXBuildFile; productRef = B8F7828C25B39C0D0015B8DF /* SFSafeSymbols */; };
+		C62D464025B3EC3D009CD1DF /* DetailsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62D463F25B3EC3D009CD1DF /* DetailsScreen.swift */; };
 		C68F98E625B38B0600CC2950 /* Quicksand-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C68F98E125B38B0500CC2950 /* Quicksand-Light.ttf */; };
 		C68F98E725B38B0600CC2950 /* Quicksand-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C68F98E225B38B0600CC2950 /* Quicksand-Medium.ttf */; };
 		C68F98E825B38B0600CC2950 /* Quicksand-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C68F98E325B38B0600CC2950 /* Quicksand-Regular.ttf */; };
@@ -77,6 +77,7 @@
 		B875497025B3D01500D646F2 /* TickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerView.swift; sourceTree = "<group>"; };
 		B8F7826F25B394200015B8DF /* DateRangePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangePickerView.swift; sourceTree = "<group>"; };
 		B8F7827725B3942F0015B8DF /* ComparsionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparsionCardView.swift; sourceTree = "<group>"; };
+		C62D463F25B3EC3D009CD1DF /* DetailsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailsScreen.swift; sourceTree = "<group>"; };
 		C68F98E125B38B0500CC2950 /* Quicksand-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Quicksand-Light.ttf"; sourceTree = "<group>"; };
 		C68F98E225B38B0600CC2950 /* Quicksand-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Quicksand-Medium.ttf"; sourceTree = "<group>"; };
 		C68F98E325B38B0600CC2950 /* Quicksand-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Quicksand-Regular.ttf"; sourceTree = "<group>"; };
@@ -215,7 +216,7 @@
 			isa = PBXGroup;
 			children = (
 				B875496325B3CA6A00D646F2 /* AnalysisScreen.swift */,
-				B843104025B391CD005544E5 /* DetailsScreen.swift */,
+				C62D463F25B3EC3D009CD1DF /* DetailsScreen.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -411,17 +412,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B8F7827025B394210015B8DF /* (null) in Sources */,
+				B8F7827025B394210015B8DF /* DateRangePickerView.swift in Sources */,
 				C68F98F925B38E5300CC2950 /* NetworkManager.swift in Sources */,
 				4DD67D8525B3E0350043EABC /* Endpoints.swift in Sources */,
 				4DD67D1625B3CFBD0043EABC /* DailyAdjustedStockModel.swift in Sources */,
 				4DD67D1425B3CFBD0043EABC /* MonthlyAdjustedStockModel.swift in Sources */,
 				B85565A125B37B7F00DD534D /* Plutus.xcdatamodeld in Sources */,
 				B875496C25B3CBC000D646F2 /* WatchListCard.swift in Sources */,
-				B843104125B391CD005544E5 /* DetailsScreen.swift in Sources */,
 				B8F7827825B3942F0015B8DF /* ComparsionCardView.swift in Sources */,
 				B875496425B3CA6A00D646F2 /* AnalysisScreen.swift in Sources */,
 				B855659E25B37B7F00DD534D /* Persistence.swift in Sources */,
+				C62D464025B3EC3D009CD1DF /* DetailsScreen.swift in Sources */,
 				B875497125B3D01500D646F2 /* TickerView.swift in Sources */,
 				4DD67D1725B3CFBD0043EABC /* WeeklyAdjustedStockModel.swift in Sources */,
 				B855659725B37B7E00DD534D /* ContentView.swift in Sources */,

--- a/Plutus.xcodeproj/project.pbxproj
+++ b/Plutus.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		B85565A125B37B7F00DD534D /* Plutus.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B855659F25B37B7F00DD534D /* Plutus.xcdatamodeld */; };
 		B85565AC25B37B7F00DD534D /* PlutusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85565AB25B37B7F00DD534D /* PlutusTests.swift */; };
 		B85565B725B37B7F00DD534D /* PlutusUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85565B625B37B7F00DD534D /* PlutusUITests.swift */; };
+		B875496425B3CA6A00D646F2 /* AnalysisScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B875496325B3CA6A00D646F2 /* AnalysisScreen.swift */; };
+		B875496C25B3CBC000D646F2 /* WatchListCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B875496B25B3CBC000D646F2 /* WatchListCard.swift */; };
+		B875497125B3D01500D646F2 /* TickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B875497025B3D01500D646F2 /* TickerView.swift */; };
 		B8F7827025B394210015B8DF /* DateRangePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F7826F25B394200015B8DF /* DateRangePickerView.swift */; };
 		B8F7827825B3942F0015B8DF /* ComparsionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F7827725B3942F0015B8DF /* ComparsionCardView.swift */; };
 		B8F7828D25B39C0D0015B8DF /* SFSafeSymbols in Frameworks */ = {isa = PBXBuildFile; productRef = B8F7828C25B39C0D0015B8DF /* SFSafeSymbols */; };
@@ -59,6 +62,9 @@
 		B85565B225B37B7F00DD534D /* PlutusUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PlutusUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B85565B625B37B7F00DD534D /* PlutusUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlutusUITests.swift; sourceTree = "<group>"; };
 		B85565B825B37B7F00DD534D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B875496325B3CA6A00D646F2 /* AnalysisScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisScreen.swift; sourceTree = "<group>"; };
+		B875496B25B3CBC000D646F2 /* WatchListCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchListCard.swift; sourceTree = "<group>"; };
+		B875497025B3D01500D646F2 /* TickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerView.swift; sourceTree = "<group>"; };
 		B8F7826F25B394200015B8DF /* DateRangePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangePickerView.swift; sourceTree = "<group>"; };
 		B8F7827725B3942F0015B8DF /* ComparsionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparsionCardView.swift; sourceTree = "<group>"; };
 		C68F98E125B38B0500CC2950 /* Quicksand-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Quicksand-Light.ttf"; sourceTree = "<group>"; };
@@ -196,6 +202,7 @@
 		C68F98FD25B38E5700CC2950 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				B875496325B3CA6A00D646F2 /* AnalysisScreen.swift */,
 				B843104025B391CD005544E5 /* DetailsScreen.swift */,
 			);
 			path = Screens;
@@ -206,6 +213,8 @@
 			children = (
 				B8F7826F25B394200015B8DF /* DateRangePickerView.swift */,
 				B8F7827725B3942F0015B8DF /* ComparsionCardView.swift */,
+				B875496B25B3CBC000D646F2 /* WatchListCard.swift */,
+				B875497025B3D01500D646F2 /* TickerView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -387,9 +396,12 @@
 				B8F7827025B394210015B8DF /* DateRangePickerView.swift in Sources */,
 				C68F98F925B38E5300CC2950 /* NetworkManager.swift in Sources */,
 				B85565A125B37B7F00DD534D /* Plutus.xcdatamodeld in Sources */,
+				B875496C25B3CBC000D646F2 /* WatchListCard.swift in Sources */,
 				B843104125B391CD005544E5 /* DetailsScreen.swift in Sources */,
 				B8F7827825B3942F0015B8DF /* ComparsionCardView.swift in Sources */,
+				B875496425B3CA6A00D646F2 /* AnalysisScreen.swift in Sources */,
 				B855659E25B37B7F00DD534D /* Persistence.swift in Sources */,
+				B875497125B3D01500D646F2 /* TickerView.swift in Sources */,
 				B855659725B37B7E00DD534D /* ContentView.swift in Sources */,
 				C68F98F025B38B2E00CC2950 /* constants.swift in Sources */,
 				B855659525B37B7E00DD534D /* PlutusApp.swift in Sources */,

--- a/Plutus/PlutusApp.swift
+++ b/Plutus/PlutusApp.swift
@@ -13,8 +13,9 @@ struct PlutusApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .environment(\.managedObjectContext, persistenceController.container.viewContext)
+//            ContentView()
+//                .environment(\.managedObjectContext, persistenceController.container.viewContext)
+            AnalysisScreen()
         }
     }
 }

--- a/Plutus/Screens/AnalysisScreen.swift
+++ b/Plutus/Screens/AnalysisScreen.swift
@@ -1,0 +1,54 @@
+//
+//  AnalysisScreen.swift
+//  Plutus
+//
+//  Created by Jared Borders on 1/16/21.
+//
+
+import SwiftUI
+
+struct AnalysisScreen: View {
+    @State private var isShowingDetailsScreen = false
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                NavigationLink(destination: DetailsScreen(), isActive: $isShowingDetailsScreen) {}
+                HStack {
+                    Text("My Watch List")
+                        .font(.custom(Fonts.quicksandSemiBold, size: 18))
+                        .padding([.top, .leading])
+                    Spacer()
+                }
+                ScrollView {
+                    WatchListCard()
+                        .padding(.top, 8)
+                        .padding(.horizontal)
+                    WatchListCard()
+                        .padding(.top, 8)
+                        .padding(.horizontal)
+                    WatchListCard()
+                        .padding(.top, 8)
+                        .padding(.horizontal)
+                    WatchListCard()
+                        .padding(.top, 8)
+                        .padding(.horizontal)
+                }
+                
+            }
+            .navigationBarTitle("Plutus", displayMode: .automatic)
+            .navigationBarItems(trailing: Button {
+                self.isShowingDetailsScreen = true
+            } label: {
+                Image(systemSymbol: .plus)
+                    .foregroundColor(.black)
+            })
+        }
+    }
+}
+
+struct AnalysisScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        AnalysisScreen()
+    }
+}

--- a/Plutus/Screens/AnalysisScreen.swift
+++ b/Plutus/Screens/AnalysisScreen.swift
@@ -9,11 +9,20 @@ import SwiftUI
 
 struct AnalysisScreen: View {
     @State private var isShowingDetailsScreen = false
-    
+
+    init() {
+        UINavigationBar.appearance().tintColor = UIColor.label
+        UINavigationBar.appearance().titleTextAttributes = [
+            NSAttributedString.Key.font: UIFont(name: Fonts.quicksandBold, size: 20)!
+        ]
+        UINavigationBar.appearance().largeTitleTextAttributes = [
+            NSAttributedString.Key.font: UIFont(name: Fonts.quicksandBold, size: 40)!
+        ]
+    }
+
     var body: some View {
         NavigationView {
-            VStack {
-                NavigationLink(destination: DetailsScreen(), isActive: $isShowingDetailsScreen) {}
+            ScrollView {
                 HStack {
                     Text("My Watch List")
                         .font(.custom(Fonts.quicksandSemiBold, size: 18))
@@ -34,21 +43,24 @@ struct AnalysisScreen: View {
                         .padding(.top, 8)
                         .padding(.horizontal)
                 }
-                
+
             }
             .navigationBarTitle("Plutus", displayMode: .automatic)
-            .navigationBarItems(trailing: Button {
-                self.isShowingDetailsScreen = true
-            } label: {
-                Image(systemSymbol: .plus)
-                    .foregroundColor(.black)
-            })
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    NavigationLink(destination: DetailsScreen()) {
+                        Image(systemSymbol: .plus)
+                    }
+                }
+            }
         }
+        .navigationViewStyle(StackNavigationViewStyle())
     }
 }
 
 struct AnalysisScreen_Previews: PreviewProvider {
     static var previews: some View {
         AnalysisScreen()
+
     }
 }

--- a/Plutus/Screens/DetailsScreen.swift
+++ b/Plutus/Screens/DetailsScreen.swift
@@ -53,7 +53,6 @@ struct DetailsScreen: View {
             }
         }
         .navigationBarTitle("Add Comparisons", displayMode: .inline)
-        .navigationViewStyle(StackNavigationViewStyle())
     }
 }
 

--- a/Plutus/Screens/DetailsScreen.swift
+++ b/Plutus/Screens/DetailsScreen.swift
@@ -11,12 +11,13 @@ struct DetailsScreen: View {
     // No state varibales yet. This all just uses moch data
     
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             DateRangePickerView()
             Divider()
-            WatchListCard()
-            Divider()
             ScrollView { // eventually this will be a ForEach
+                WatchListCard()
+                    .padding(.top)
+                Divider()
                 ComparsionCardView(name: "BTC",
                                    currentValue: 44000,
                                    percentChange: 10,
@@ -51,7 +52,7 @@ struct DetailsScreen: View {
                     .padding(.horizontal)
             }
         }
-        .navigationTitle("Add Comparisons")
+        .navigationBarTitle("Add Comparisons", displayMode: .inline)
         .navigationViewStyle(StackNavigationViewStyle())
     }
 }

--- a/Plutus/Screens/DetailsScreen.swift
+++ b/Plutus/Screens/DetailsScreen.swift
@@ -11,43 +11,48 @@ struct DetailsScreen: View {
     // No state varibales yet. This all just uses moch data
     
     var body: some View {
-        NavigationView {
-            VStack {
-                DateRangePickerView()
-                Divider()
-                Text("📈") // GraphView will eventually go here @elena
-                    .padding()
-                Divider()
-                ScrollView { // eventually this will be a ForEach
-                    ComparsionCardView(name: "BTC",
-                                       currentValue: 44000,
-                                       percentChange: 10,
-                                       valueChange: 4000,
-                                       dateRange: DateRanges.Day,
-                                       isSelected: true)
-                        .padding(.vertical, 6)
-                        .padding(.horizontal)
-                    ComparsionCardView(name: "ETH",
-                                       currentValue: 1400,
-                                       percentChange: -8.3,
-                                       valueChange: -113,
-                                       dateRange: DateRanges.Day,
-                                       isSelected: false)
-                        .padding(.vertical, 6)
-                        .padding(.horizontal)
-                    ComparsionCardView(name: "S&P 500",
-                                       currentValue: 3768.25,
-                                       percentChange: -0.72,
-                                       valueChange: 27.29,
-                                       dateRange: DateRanges.Day,
-                                       isSelected: false)
-                        .padding(.vertical, 6)
-                        .padding(.horizontal)
-                }
+        VStack {
+            DateRangePickerView()
+            Divider()
+            WatchListCard()
+            Divider()
+            ScrollView { // eventually this will be a ForEach
+                ComparsionCardView(name: "BTC",
+                                   currentValue: 44000,
+                                   percentChange: 10,
+                                   valueChange: 4000,
+                                   dateRange: DateRanges.Day,
+                                   isSelected: true)
+                    .padding(.vertical, 6)
+                    .padding(.horizontal)
+                ComparsionCardView(name: "DOW",
+                                   currentValue: 30814.26,
+                                   percentChange: -0.57,
+                                   valueChange: -177.26,
+                                   dateRange: DateRanges.Day,
+                                   isSelected: true)
+                    .padding(.vertical, 6)
+                    .padding(.horizontal)
+                ComparsionCardView(name: "ETH",
+                                   currentValue: 1400,
+                                   percentChange: -8.3,
+                                   valueChange: -113,
+                                   dateRange: DateRanges.Day,
+                                   isSelected: false)
+                    .padding(.vertical, 6)
+                    .padding(.horizontal)
+                ComparsionCardView(name: "S&P 500",
+                                   currentValue: 3768.25,
+                                   percentChange: -0.72,
+                                   valueChange: 27.29,
+                                   dateRange: DateRanges.Day,
+                                   isSelected: false)
+                    .padding(.vertical, 6)
+                    .padding(.horizontal)
             }
-            .navigationTitle("Add Comparisons")
-            .navigationViewStyle(StackNavigationViewStyle())
         }
+        .navigationTitle("Add Comparisons")
+        .navigationViewStyle(StackNavigationViewStyle())
     }
 }
 

--- a/Plutus/Views/ComparsionCardView.swift
+++ b/Plutus/Views/ComparsionCardView.swift
@@ -31,29 +31,29 @@ struct ComparsionCardView: View {
             HStack {
                 VStack(alignment: .leading) {
                     HStack {
-                        (postiveChange ? Image(systemSymbol: .arrowDownRight) : Image(systemSymbol: .arrowUpForward))
+                        (postiveChange ? Image(systemSymbol: .arrowUpForward) : Image(systemSymbol: .arrowDownRight))
                             .foregroundColor(postiveChange ? .green : .red)
                         Text(name)
-                            .font(.custom(Fonts.quicksandSemiBold, size: 18))
+                            .font(.custom(Fonts.quicksandSemiBold, size: 16))
                     }
                     Text("$\(currentValueStr)")
-                        .font(.custom(Fonts.quicksandLight, size: 18))
+                        .font(.custom(Fonts.quicksandLight, size: 16))
                 }
                 .padding(.vertical)
                 Spacer()
                 VStack(alignment: .center) {
                     Text(dateRange.rawValue)
-                        .font(.custom(Fonts.quicksandSemiBold, size: 18))
-                    Text("%\(percentChangeStr)")
-                        .font(.custom(Fonts.quicksandSemiBold, size: 18))
+                        .font(.custom(Fonts.quicksandSemiBold, size: 16))
+                    Text("\(postiveChange ? "+" : "-")$\(valueChangeStr)")
+                        .font(.custom(Fonts.quicksandSemiBold, size: 16))
                         .foregroundColor(postiveChange ? .green : .red)
-                    Text("\(postiveChange ? "+" : "-")\(valueChangeStr)")
-                        .font(.custom(Fonts.quicksandSemiBold, size: 18))
+                    Text("\(percentChangeStr)%")
+                        .font(.custom(Fonts.quicksandSemiBold, size: 16))
                         .foregroundColor(postiveChange ? .green : .red)
                 }
                 .padding(.vertical)
             }
-            .padding(.horizontal)
+            .padding(.horizontal, 50)
         }
         .overlay(
             RoundedRectangle(cornerRadius: 16)

--- a/Plutus/Views/TickerView.swift
+++ b/Plutus/Views/TickerView.swift
@@ -1,0 +1,47 @@
+//
+//  TickerView.swift
+//  Plutus
+//
+//  Created by Jared Borders on 1/16/21.
+//
+
+import SwiftUI
+
+struct TickerView: View {
+    var name: String
+    var currentValue: Float
+    var percentChange: Float
+    var valueChange: Float
+    var dateRange: DateRanges
+    
+    // Float -> String
+    private var currentValueStr: String { NSString(format: "%.2f", currentValue) as String }
+    private var percentChangeStr: String { NSString(format: "%.2f", abs(percentChange)) as String }
+    private var valueChangeStr: String { NSString(format: "%.2f", abs(valueChange)) as String }
+    
+    var postiveChange: Bool {
+        percentChange > 0 ? true : false
+    }
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                (postiveChange ? Image(systemSymbol: .arrowUpForward) : Image(systemSymbol: .arrowDownRight))
+                    .foregroundColor(postiveChange ? .green : .red)
+                Text(name)
+                    .font(.custom(Fonts.quicksandSemiBold, size: 16))
+            }
+            Text("\(postiveChange ? "+" : "-" )$\(valueChangeStr) (\(postiveChange ? "+" : "-" )\(percentChangeStr)%)")
+                .font(.custom(Fonts.quicksandSemiBold, size: 16))
+                .foregroundColor(postiveChange ? .green : .red)
+            Text("$\(currentValueStr)")
+                .font(.custom(Fonts.quicksandLight, size: 16))
+        }
+        .padding(.vertical)
+    }
+}
+
+struct TickerView_Previews: PreviewProvider {
+    static var previews: some View {
+        TickerView(name: "DOW", currentValue: 30814.26, percentChange: -0.57, valueChange: -177.26, dateRange: DateRanges.Day)
+    }
+}

--- a/Plutus/Views/WatchListCard.swift
+++ b/Plutus/Views/WatchListCard.swift
@@ -1,0 +1,38 @@
+//
+//  WatchListCard.swift
+//  Plutus
+//
+//  Created by Jared Borders on 1/16/21.
+//
+
+import SwiftUI
+
+struct WatchListCard: View {
+    var body: some View {
+        VStack(alignment: .leading) {
+            VStack {
+                Text("📈 Elena's Graph") // GraphView will eventually go here @elena
+                    .padding(80)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke(Color.gray, lineWidth: 1)
+                    )
+                HStack {
+                    TickerView(name: "BTC", currentValue: 40000, percentChange: 10, valueChange: 4000, dateRange: DateRanges.Day)
+                    TickerView(name: "DOW", currentValue: 30814.26, percentChange: -0.57, valueChange: -177.26, dateRange: DateRanges.Day)
+                }
+            }
+            .padding()
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color.gray, lineWidth: 1)
+        )
+    }
+}
+
+struct WatchListCard_Previews: PreviewProvider {
+    static var previews: some View {
+        WatchListCard()
+    }
+}


### PR DESCRIPTION
Build analysis screen which is the first screen the user will see after opening the app. It contains a list of comparison cards which contains ticker data for two ticker symbols and a chart (soon) comparing them (currently all that is seen is mock data).

A trailing navigation button link to the detailsScreen now exists. (this functionality will be changed, once we allow for the comparison cards to act as links. In the future, the trailing navigation button will open a screen allowing a user to create a new comparison card)